### PR TITLE
ci: use multi env for docker build

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -1,12 +1,8 @@
 name: docker_build_push
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  release:
+    types: [created]
 
 env:
   REGISTRY: ghcr.io
@@ -15,10 +11,11 @@ env:
 jobs:
   docker:
     name: Build and push docker image to GitHub Container Registry
-    environment: devnet-1
+    strategy:
+      matrix:
+        environment: [devnet-1]
     runs-on: ubuntu-latest-16-core
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
+    environment: ${{ matrix.environment }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -44,10 +41,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},suffix=${{ format('-{0}', matrix.environment) }}
+            type=semver,pattern={{major}}.{{minor}},suffix=${{ format('-{0}', matrix.environment) }}
 
       - name: Push to GitHub Container Registry
         uses: docker/build-push-action@v3


### PR DESCRIPTION
# Description

This PR updates the docker build workflow so that docker images are tagged with environment. This is necessary as environment-specific env variable values are needed at build time.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
