### PR TITLE
fix: check if ip address when sanitizing urls

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,20 @@ export function shortenAddress(
 }
 
 export function sanitizeURLProtocol(protocol: 'ws' | 'http', endpoint: string) {
-  return location.protocol.startsWith('https')
+  return location.protocol.startsWith('https') &&
+    endpoint.indexOf('localhost') === -1 &&
+    !isStringIpAddress(endpoint)
     ? `${protocol}s://${endpoint}`
     : `${protocol}://${endpoint}`
+}
+
+function isStringIpAddress(value: string) {
+  if (
+    /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(
+      value
+    )
+  ) {
+    return true
+  }
+  return false
 }


### PR DESCRIPTION
# Description

This PR fixes the URL sanitization util function so that it checks if `endpoint` is an ip address (and doesn't use secure connections in that case).

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
