### PR TITLE
fix: import typechecks from full paths

### DIFF
--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -1,9 +1,7 @@
 import * as ToposCoreJSON from '@topos-protocol/topos-smart-contracts/artifacts/contracts/topos-core/ToposCore.sol/ToposCore.json'
 import * as ERC20MessagingJSON from '@topos-protocol/topos-smart-contracts/artifacts/contracts/examples/ERC20Messaging.sol/ERC20Messaging.json'
-import {
-  ERC20Messaging,
-  ToposCore,
-} from '@topos-protocol/topos-smart-contracts/typechain-types'
+import { ToposCore } from '@topos-protocol/topos-smart-contracts/typechain-types/contracts/topos-core'
+import { ERC20Messaging } from '@topos-protocol/topos-smart-contracts/typechain-types/contracts/examples'
 import { ethers } from 'ethers'
 
 export const toposCoreContract = new ethers.Contract(

--- a/src/hooks/useRegisteredSubnets.ts
+++ b/src/hooks/useRegisteredSubnets.ts
@@ -1,4 +1,4 @@
-import { SubnetRegistrator__factory } from '@topos-protocol/topos-smart-contracts/typechain-types'
+import { SubnetRegistrator__factory } from '@topos-protocol/topos-smart-contracts/typechain-types/factories/contracts/topos-core'
 import { ethers } from 'ethers'
 import { useContext, useEffect, useMemo, useState } from 'react'
 import { ErrorsContext } from '../contexts/errors'


### PR DESCRIPTION
# Description

This PR fixes failing `npm build` by updating contracts' typechecks import to full paths (to prevent a OpenZeppelin's tsc error).

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
