### PR TITLE
fix: update cert effect on cert page

### DIFF
--- a/src/hooks/useSubnetGetCertificateById.tsx
+++ b/src/hooks/useSubnetGetCertificateById.tsx
@@ -57,12 +57,13 @@ export default function useSubnetGetCertificateById({
             ...e,
             `Could not find a certificate with the provided id (${certificateId})`,
           ])
+          setCertificate(undefined)
         } else {
           setCertificate(data?.certificate)
         }
       }
     },
-    [data?.certificate]
+    [data?.certificate, selectedSubnet]
   )
 
   return { certificate, error, loading }


### PR DESCRIPTION
# Description

This PR fixes the Certificate page by having the effect that checks whether the cert's subnet is the selected subnet triggered on new subnet selection.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
