### PR TITLE
fix: add missing check when checking for cert-subnet

### DIFF
--- a/src/hooks/useSubnetGetCertificateById.tsx
+++ b/src/hooks/useSubnetGetCertificateById.tsx
@@ -51,7 +51,8 @@ export default function useSubnetGetCertificateById({
       if (data) {
         if (
           !data?.certificate ||
-          data.certificate.sourceSubnetId !== selectedSubnet?.id
+          (data.certificate.sourceSubnetId !== selectedSubnet?.id &&
+            selectedSubnet)
         ) {
           setErrors((e) => [
             ...e,


### PR DESCRIPTION
# Description

This PR adds an additional fix to #16 to make sure `Not found certificate` error is not triggered mistakenly.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
