### PR TITLE
fix: delay cert subscription iteration

### DIFF
--- a/src/hooks/useSubnetSubscribeToCertificates.tsx
+++ b/src/hooks/useSubnetSubscribeToCertificates.tsx
@@ -50,7 +50,9 @@ export default function useSubnetSubscribeToCertificates({
 
   useEffect(
     function storeLatestCurrentIndexes() {
-      currentIndexesRef.current = currentIndexes
+      window.setTimeout(() => {
+        currentIndexesRef.current = currentIndexes
+      }, 500)
     },
     [currentIndexes]
   )


### PR DESCRIPTION
# Description

This PR adds a delay to the certificate subscription query trigger so that the out-of-focus -> focus event on a browser window/tab doesn't trigger a cascade of queries to the graphQL endpoint of the TCE.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
