### PR TITLE
feat: use new subnet endpoint fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@apollo/client": "^3.7.15",
         "@emotion/react": "11.10.6",
         "@emotion/styled": "11.10.6",
-        "@topos-protocol/topos-smart-contracts": "^1.2.2",
+        "@topos-protocol/topos-smart-contracts": "^2.0.0-rc1",
         "3d-force-graph": "^1.71.4",
         "antd": "^5.10.1",
         "axios": "^1.4.0",
@@ -4443,9 +4443,9 @@
       }
     },
     "node_modules/@topos-protocol/topos-smart-contracts": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@topos-protocol/topos-smart-contracts/-/topos-smart-contracts-1.2.2.tgz",
-      "integrity": "sha512-x0rkGALx493ty8E2AKeaVhaUvC7SzenMwjAf2UsMwF9V9n9lfmAQv2T2DquGa/GG+Hdyl3BHO3U4f8V+Q6ytwA==",
+      "version": "2.0.0-rc1",
+      "resolved": "https://registry.npmjs.org/@topos-protocol/topos-smart-contracts/-/topos-smart-contracts-2.0.0-rc1.tgz",
+      "integrity": "sha512-EXSNF+RXL5kxMCBvlDIhNqBaWtf3X7fbetg65wvryuM3+m6rzcKHW2ZDiKbjoVVK/GuVwFD6tJzv3K5tjwNMaw==",
       "dependencies": {
         "@openzeppelin/contracts": "^4.8.3",
         "ethers": "^5.7.2",
@@ -15694,9 +15694,9 @@
       }
     },
     "@topos-protocol/topos-smart-contracts": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@topos-protocol/topos-smart-contracts/-/topos-smart-contracts-1.2.2.tgz",
-      "integrity": "sha512-x0rkGALx493ty8E2AKeaVhaUvC7SzenMwjAf2UsMwF9V9n9lfmAQv2T2DquGa/GG+Hdyl3BHO3U4f8V+Q6ytwA==",
+      "version": "2.0.0-rc1",
+      "resolved": "https://registry.npmjs.org/@topos-protocol/topos-smart-contracts/-/topos-smart-contracts-2.0.0-rc1.tgz",
+      "integrity": "sha512-EXSNF+RXL5kxMCBvlDIhNqBaWtf3X7fbetg65wvryuM3+m6rzcKHW2ZDiKbjoVVK/GuVwFD6tJzv3K5tjwNMaw==",
       "requires": {
         "@openzeppelin/contracts": "^4.8.3",
         "ethers": "^5.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@apollo/client": "^3.7.15",
         "@emotion/react": "11.10.6",
         "@emotion/styled": "11.10.6",
-        "@topos-protocol/topos-smart-contracts": "^2.0.0-rc1",
+        "@topos-protocol/topos-smart-contracts": "^2.0.0",
         "3d-force-graph": "^1.71.4",
         "antd": "^5.10.1",
         "axios": "^1.4.0",
@@ -4443,9 +4443,9 @@
       }
     },
     "node_modules/@topos-protocol/topos-smart-contracts": {
-      "version": "2.0.0-rc1",
-      "resolved": "https://registry.npmjs.org/@topos-protocol/topos-smart-contracts/-/topos-smart-contracts-2.0.0-rc1.tgz",
-      "integrity": "sha512-EXSNF+RXL5kxMCBvlDIhNqBaWtf3X7fbetg65wvryuM3+m6rzcKHW2ZDiKbjoVVK/GuVwFD6tJzv3K5tjwNMaw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@topos-protocol/topos-smart-contracts/-/topos-smart-contracts-2.0.0.tgz",
+      "integrity": "sha512-9ElAqlPg7puWCH0F58l7TgnXheybzkmyNr2ssla/olwKRxcfKJl10k3U5CN03KaTkbkZY+Jhp5JW7BLL+8xhNA==",
       "dependencies": {
         "@openzeppelin/contracts": "^4.8.3",
         "ethers": "^5.7.2",
@@ -15694,9 +15694,9 @@
       }
     },
     "@topos-protocol/topos-smart-contracts": {
-      "version": "2.0.0-rc1",
-      "resolved": "https://registry.npmjs.org/@topos-protocol/topos-smart-contracts/-/topos-smart-contracts-2.0.0-rc1.tgz",
-      "integrity": "sha512-EXSNF+RXL5kxMCBvlDIhNqBaWtf3X7fbetg65wvryuM3+m6rzcKHW2ZDiKbjoVVK/GuVwFD6tJzv3K5tjwNMaw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@topos-protocol/topos-smart-contracts/-/topos-smart-contracts-2.0.0.tgz",
+      "integrity": "sha512-9ElAqlPg7puWCH0F58l7TgnXheybzkmyNr2ssla/olwKRxcfKJl10k3U5CN03KaTkbkZY+Jhp5JW7BLL+8xhNA==",
       "requires": {
         "@openzeppelin/contracts": "^4.8.3",
         "ethers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@apollo/client": "^3.7.15",
     "@emotion/react": "11.10.6",
     "@emotion/styled": "11.10.6",
-    "@topos-protocol/topos-smart-contracts": "^1.2.2",
+    "@topos-protocol/topos-smart-contracts": "^2.0.0-rc1",
     "3d-force-graph": "^1.71.4",
     "antd": "^5.10.1",
     "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@apollo/client": "^3.7.15",
     "@emotion/react": "11.10.6",
     "@emotion/styled": "11.10.6",
-    "@topos-protocol/topos-smart-contracts": "^2.0.0-rc1",
+    "@topos-protocol/topos-smart-contracts": "^2.0.0",
     "3d-force-graph": "^1.71.4",
     "antd": "^5.10.1",
     "axios": "^1.4.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,6 @@ import AppInternals from './AppInternals'
 import { TourRefsContext } from './contexts/tourRefs'
 import useSubnetGetLatestBlockNumber from './hooks/useSubnetGetLatestBlockNumber'
 import { CrossSubnetMessagesGraphContext } from './contexts/crossSubnetMessagesGraph'
-import { sanitizeURLProtocol } from './utils'
 
 const Errors = styled.div`
   margin: 1rem auto;
@@ -68,7 +67,7 @@ const App = () => {
   const apolloClient = useMemo(
     () =>
       new ApolloClient({
-        uri: sanitizeURLProtocol('http', selectedTCEEndpoint || ''),
+        uri: selectedTCEEndpoint,
         cache: new InMemoryCache(),
       }),
     [selectedTCEEndpoint]

--- a/src/components/NetworkSelector.tsx
+++ b/src/components/NetworkSelector.tsx
@@ -1,7 +1,6 @@
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons'
 import { Divider, Form, Input, Select, Space, Button } from 'antd'
 import React, { useState, useCallback, useEffect, ReactNode } from 'react'
-import { removeURLProtocol } from '../utils'
 
 interface Props {
   allowCustomItems: boolean
@@ -44,7 +43,7 @@ const NetworkSelector = ({
   const addItem = useCallback(
     (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
       e.preventDefault()
-      setCustomItems((items) => [...items, removeURLProtocol(newCustomItem)])
+      setCustomItems((items) => [...items, newCustomItem])
       setNewCustomItem('')
     },
     [newCustomItem]

--- a/src/components/NetworksMenu.tsx
+++ b/src/components/NetworksMenu.tsx
@@ -69,9 +69,10 @@ const NetworksMenu = () => {
               <Space direction="vertical" size={0}>
                 <Text>Select a Topos Subnet endpoint</Text>
                 {Boolean(selectedToposSubnet) && (
-                  <Text
-                    strong
-                  >{`(currently: ${selectedToposSubnet?.endpoint})`}</Text>
+                  <Text strong>{`(currently: ${
+                    selectedToposSubnet?.endpointWs ||
+                    selectedToposSubnet?.endpointHttp
+                  })`}</Text>
                 )}
               </Space>
             }

--- a/src/components/SubnetInfo.tsx
+++ b/src/components/SubnetInfo.tsx
@@ -101,7 +101,7 @@ const SubnetInfo = () => {
           {selectedSubnet?.currencySymbol}
         </Descriptions.Item>
         <Descriptions.Item label="RPC Endpoint">
-          {selectedSubnet?.endpoint}
+          {selectedSubnet?.endpointWs} | {selectedSubnet?.endpointHttp}
         </Descriptions.Item>
       </Descriptions>
       <Row gutter={16}>

--- a/src/components/ToposSubnetSelector.tsx
+++ b/src/components/ToposSubnetSelector.tsx
@@ -57,7 +57,9 @@ const ToposSubnetSelector = () => {
         label: i,
         value: i,
       }))}
-      initialValue={selectedToposSubnet?.endpoint}
+      initialValue={
+        selectedToposSubnet?.endpointWs || selectedToposSubnet?.endpointHttp
+      }
       fixedItems={liveNetworkItems.map((i) => ({
         label: i,
         value: i,

--- a/src/hooks/useSubnetGetLatestBlockNumber.ts
+++ b/src/hooks/useSubnetGetLatestBlockNumber.ts
@@ -1,9 +1,8 @@
-import { useCallback, useContext } from 'react'
-import { ErrorsContext } from '../contexts/errors'
-
-import { Subnet } from '../types'
 import { providers } from 'ethers'
-import { sanitizeURLProtocol } from '../utils'
+import { useCallback, useContext } from 'react'
+
+import { ErrorsContext } from '../contexts/errors'
+import { Subnet } from '../types'
 
 export default function useSubnetGetLatestBlockNumber() {
   const { setErrors } = useContext(ErrorsContext)
@@ -11,9 +10,11 @@ export default function useSubnetGetLatestBlockNumber() {
   const getSubnetLatestBlockNumber = useCallback((subnet?: Subnet) => {
     if (subnet) {
       try {
-        const provider = new providers.JsonRpcProvider(
-          sanitizeURLProtocol('http', subnet.endpoint)
-        )
+        const endpoint = subnet.endpointHttp || subnet.endpointWs
+        const url = new URL(endpoint)
+        const provider = url.protocol.startsWith('ws')
+          ? new providers.WebSocketProvider(subnet.endpointWs)
+          : new providers.JsonRpcProvider(subnet.endpointHttp)
         return provider.getBlockNumber()
       } catch (error) {
         setErrors((e) => [

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,8 @@ import { BigNumber } from 'ethers'
 import { Certificate as CertificateFromQuery } from './__generated__/graphql'
 
 export interface Subnet {
-  endpoint: string
+  endpointHttp: string
+  endpointWs: string
   logoURL: string
   name: string
   currencySymbol: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,24 +6,3 @@ export function shortenAddress(
     address.length - prefixSuffixLength
   )}`
 }
-
-export function sanitizeURLProtocol(protocol: 'ws' | 'http', endpoint: string) {
-  return endpoint.indexOf('localhost') === -1 && !isIPAddressWithPort(endpoint)
-    ? `${protocol}s://${endpoint}`
-    : `${protocol}://${endpoint}`
-}
-
-export function removeURLProtocol(endpoint: string) {
-  return endpoint.startsWith('http://') ||
-    endpoint.startsWith('https://') ||
-    endpoint.startsWith('ws://') ||
-    endpoint.startsWith('wss://')
-    ? new URL(endpoint).host
-    : endpoint
-}
-
-function isIPAddressWithPort(input: string): boolean {
-  // Regular expression to match an IP address with an optional port
-  const ipWithPortRegex = /^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(:\d+)?$/
-  return ipWithPortRegex.test(input)
-}


### PR DESCRIPTION
# Description

This PR reflects https://github.com/topos-protocol/topos-smart-contracts/pull/112

## Additions and Changes

- Network endpoints are now full urls (with the right protocol)
- The explorer works both with ws and http endpoints

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
