### PR TITLE
fix: reset certs sub on subnet change

### DIFF
--- a/src/hooks/useSubnetSubscribeToCertificates.tsx
+++ b/src/hooks/useSubnetSubscribeToCertificates.tsx
@@ -40,11 +40,21 @@ export default function useSubnetSubscribeToCertificates({ filter }: Options) {
     },
   })
 
-  useEffect(() => {
-    if (data && data.watchDeliveredCertificates) {
-      setCertificates((c) => [data.watchDeliveredCertificates, ...c])
-    }
-  }, [data])
+  useEffect(
+    function onNewFilter() {
+      setCertificates([])
+    },
+    [filter?.source]
+  )
+
+  useEffect(
+    function onNewCertificates() {
+      if (data && data.watchDeliveredCertificates) {
+        setCertificates((c) => [data.watchDeliveredCertificates, ...c])
+      }
+    },
+    [data]
+  )
 
   return { certificates, error, loading }
 }


### PR DESCRIPTION
# Description

This PR fixes the certificate subscription so that the list of certs is reset on subnet update.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
